### PR TITLE
Document IFEval-Audio run path, add SALMONN-7B example, note deps

### DIFF
--- a/IFEval-Audio/README.md
+++ b/IFEval-Audio/README.md
@@ -10,6 +10,34 @@ IFEval-Audio is a dataset to evaluate instruction-following in audio-based LLMs,
 - **Dimensions**: Content, Capitalization, Symbol, List Structure, Length, Format.
 - **Distribution**: 240 speech triples (40/dimension), 40 music/environmental triples.
 
+## Dataset
+The dataset is hosted on Hugging Face: [`YichenG170/AudioLLMInstructionFollowing`](https://huggingface.co/datasets/YichenG170/AudioLLMInstructionFollowing)
+(you may need to log in and accept the access conditions). It is loaded automatically by the
+evaluation code — no manual download is required.
+
+## How to Run
+IFEval-Audio is integrated into AudioBench as the dataset `audiollm_instructionfollowing`
+with the metric `llama3_70b_judge_combined`. From the repo root:
+
+```shell
+# Step 1 (separate process): serve the Llama-3-70B judge used to score correctness.
+bash vllm_model_judge_llama_3_70b.sh
+
+# Step 2: run inference + evaluation for your model.
+GPU=0
+BATCH_SIZE=1
+OVERWRITE=True
+NUMBER_OF_SAMPLES=-1               # -1 = all 280 triples
+
+MODEL_NAME=Qwen2-Audio-7B-Instruct # any supported model
+DATASET=audiollm_instructionfollowing
+METRICS=llama3_70b_judge_combined
+
+bash eval.sh $DATASET $MODEL_NAME $GPU $BATCH_SIZE $OVERWRITE $METRICS $NUMBER_OF_SAMPLES
+```
+
+The judge reports the three metrics below, broken down by the six dimensions.
+
 ## Evaluation Metrics
 IFR: Format adherence score (0/1).
 SCR: Semantic correctness score (0/1).

--- a/examples/eval_SALMONN_7B.sh
+++ b/examples/eval_SALMONN_7B.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
+# Example: evaluate SALMONN-7B on AudioBench.
+#
+# Prerequisite (one-time): download the model checkpoint into examples/.
+#   cd examples
+#   # needs Git LFS to fetch the large checkpoint files, e.g. `apt install git-lfs`
+#   git clone https://huggingface.co/AudioLLMs/SALMONN_7B
+#   cd ..
+#
+# Then run this script from the repo root:
+#   bash examples/eval_SALMONN_7B.sh
+#
+# For model-as-judge metrics (e.g. llama3_70b_judge), first start the judge
+# server in a separate process:  bash vllm_model_judge_llama_3_70b.sh
+# =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
+
+
+# =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
+MODEL_NAME=SALMONN_7B
+# =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
+GPU=0
+BATCH_SIZE=1
+OVERWRITE=False
+NUMBER_OF_SAMPLES=-1   # -1 means use all test samples
+# =  =  =  =  =  =  =  =  =  =  =  =  =  =  =
+
+
+# Example task: English ASR on LibriSpeech (word error rate).
+DATASET=librispeech_test_clean
+METRICS=wer
+
+bash eval.sh $DATASET $MODEL_NAME $GPU $BATCH_SIZE $OVERWRITE $METRICS $NUMBER_OF_SAMPLES

--- a/examples/supported_datasets.md
+++ b/examples/supported_datasets.md
@@ -154,6 +154,10 @@ METRIC=acc
 DATASET=spoken-mqa_multi_step_reasoning
 METRIC=acc
 
+# IFEval-Audio (instruction following). Reports IFR / SCR / OSR.
+DATASET=audiollm_instructionfollowing
+METRIC=llama3_70b_judge_combined
+
 
 # == == == == == Audio Scene Question Answering == == == == ==
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,15 @@
-transformers
+# NOTE on versions:
+# These are unpinned. For a reproducible environment, install and then freeze the
+# exact versions that work on your machine:
+#     pip install -r requirements.txt
+#     pip freeze > requirements.lock.txt
+#
+# `transformers` is the most version-sensitive dependency: Qwen2-Audio requires a
+# recent release (>= 4.45), but some newer releases have regressed audio model
+# behaviour. If Qwen2-Audio misbehaves, pin `transformers` to a known-good version
+# for your setup. See issue #10.
+
+transformers>=4.45
 vllm
 fire
 evaluate
@@ -12,6 +23,5 @@ autoawq
 huggingface-hub
 google-generativeai
 openai
-fire
 librosa
 soundfile


### PR DESCRIPTION
Tidy-up addressing several open issues. Docs/scripts only — no source logic changes.

## Changes
- **IFEval-Audio README** — add `Dataset` (links the HF dataset `YichenG170/AudioLLMInstructionFollowing`) and `How to Run` sections. The benchmark was already wired into the code (`audiollm_instructionfollowing` + `llama3_70b_judge_combined`); the README just never documented it. Fixes #15.
- **examples/supported_datasets.md** — list `audiollm_instructionfollowing` under Speech Instruction.
- **examples/eval_SALMONN_7B.sh** — add the launch script the docs reference but which was missing. The `SALMONN_7B` loader already exists in `src/`. Fixes #9.
- **requirements.txt** — add a reproducibility note (pip freeze), pin `transformers>=4.45` for Qwen2-Audio, drop a duplicate `fire`. Re #10 (exact pins still best generated from a working GPU env).

## Not included
- #10 exact version lock — needs a `pip freeze` from a verified environment.
- #4 / #11 are already answered and can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)